### PR TITLE
Move classic dependency into the rockspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,6 @@ The API is loosely inspired by a mix of XPath, CSS queries, and .NET's LINQ.
 See below for a simple example, and a more complete example of extracting things from an LSTM.
 
 ## Installation
-Install `classic` (a class library from DeepMind) first:
-```
-luarocks install https://raw.githubusercontent.com/deepmind/classic/master/rocks/classic-scm-1.rockspec
-```
 Install `nnquery`:
 ```
 luarocks install https://raw.githubusercontent.com/bshillingford/nnquery/master/rocks/nnquery-scm-1.rockspec

--- a/rocks/nnquery-scm-1.rockspec
+++ b/rocks/nnquery-scm-1.rockspec
@@ -16,7 +16,7 @@ description = {
 dependencies = {
   'lua >= 5.1',
   'torch',
-  -- classic also required: https://github.com/deepmind/classic
+  'classic'
 }
 
 build = {


### PR DESCRIPTION
Since I added `classic` to Torch's luarocks repo, it can now go directly into the rockspec.
